### PR TITLE
Implement hot-reload support (default off).

### DIFF
--- a/sview/SVMain.cc
+++ b/sview/SVMain.cc
@@ -3,11 +3,15 @@
 
 #include <stdio.h>
 
+#include <QFileSystemWatcher>
+
 SVMain::SVMain(QWidget *parent) : QMainWindow(parent)
 {
   state_load(schem_file);
   svmain = this;
   setupUi(this);
+  schem_watch = new QFileSystemWatcher;
+  QObject::connect(schem_watch, SIGNAL(fileChanged(const QString &)), display_widget, SLOT(reload()));
   nlist = NULL;
 }
 
@@ -40,13 +44,22 @@ void SVMain::track(int net)
     QObject::connect(nlist, SIGNAL(state_change_up()), this, SLOT(state_changed()));
     QObject::connect(nlist, SIGNAL(closed()), this, SLOT(net_list_closed()));
   }
-  nlist->show();  
+  nlist->show();
   nlist->add_net(net);
 }
 
 void SVMain::state_changed()
 {
   state_change();
+}
+
+void SVMain::auto_reload_toggle(bool enabled)
+{
+  if(enabled) {
+      schem_watch->addPath(schem_file);
+  } else {
+      schem_watch->removePath(schem_file);
+  }
 }
 
 void SVMain::close()

--- a/sview/SVMain.h
+++ b/sview/SVMain.h
@@ -4,6 +4,8 @@
 #include "ui_SVMainUI.h"
 #include "NetStateList.h"
 
+#include <QFileSystemWatcher>
+
 class SVMain : public QMainWindow, private Ui::SVMainUI {
   Q_OBJECT
 
@@ -21,9 +23,11 @@ public slots:
   void state_changed();
   void close();
   void net_list_closed();
+  void auto_reload_toggle(bool);
 
 private:
   NetStateList *nlist;
+  QFileSystemWatcher *schem_watch;
 };
 
 #endif

--- a/sview/SVMainUI.ui
+++ b/sview/SVMainUI.ui
@@ -56,7 +56,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>19</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -80,8 +80,15 @@
     <addaction name="actionTrace_next"/>
     <addaction name="actionTrace_prev"/>
    </widget>
+   <widget class="QMenu" name="menuOptions">
+    <property name="title">
+     <string>Options</string>
+    </property>
+    <addaction name="actionAuto_Reload"/>
+   </widget>
    <addaction name="menu_File"/>
    <addaction name="menuZoom"/>
+   <addaction name="menuOptions"/>
    <addaction name="menuTrace"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
@@ -102,6 +109,9 @@
    </property>
   </action>
   <action name="actionZoom_Out">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="text">
     <string>Zoom &amp;Out</string>
    </property>
@@ -131,6 +141,14 @@
    </property>
    <property name="shortcut">
     <string>Left</string>
+   </property>
+  </action>
+  <action name="actionAuto_Reload">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Auto-Reload</string>
    </property>
   </action>
  </widget>
@@ -315,6 +333,22 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>actionAuto_Reload</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>SVMainUI</receiver>
+   <slot>auto_reload_toggle(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>399</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <signal>state_change()</signal>
@@ -323,5 +357,6 @@
   <slot>track(int)</slot>
   <slot>state_changed()</slot>
   <slot>net_list_closed()</slot>
+  <slot>auto_reload_toggle(bool)</slot>
  </slots>
 </ui>


### PR DESCRIPTION
One of the two "must-have" features I need.

When the schematic is updated externally, the screen will be reloaded to reflect your changes. This can be toggled using a new option on the menubar.